### PR TITLE
Fixed can't parse S3 access logs with double quotes on the UA.

### DIFF
--- a/source/lambda/es_loader/aws.ini
+++ b/source/lambda/es_loader/aws.ini
@@ -444,7 +444,7 @@ geoip = source destination
 # https://aws.amazon.com/jp/premiumsupport/knowledge-center/analyze-logs-athena/
 s3_key = s3accesslog
 # s3_key = 20\d{2}-[01]\d-\d{2}-\d{2}-\d{2}-\d{2}-[0-9A-Z]{16}$$
-log_pattern = (?P<BucketOwner>[^ ]*) (?P<Bucket>[^ ]*) \[(?P<RequestDateTime>.*?)\] (?P<RemoteIP>[^ ]*) (?P<Requester>[^ ]*) (?P<RequestID>[^ ]*) (?P<Operation>[^ ]*) (?P<Key>[^ ]*) (\"(?P<RequestURI_operation>[^ ]*) (?P<RequestURI_key>[^ ]*) (?P<RequestURI_httpProtoversion>- |[^ ]*)\"|\"-\"|-) (?P<HTTPstatus>-|[0-9]*) (?P<ErrorCode>[^ ]*) (?P<BytesSent>[^ ]*) (?P<ObjectSize>[^ ]*) (?P<TotalTime>[^ ]*) (?P<TurnAroundTime>[^ ]*) (\"(?P<Referrer>[^ ]*)\"|-) (\"(?P<UserAgent>[^\"]*)\"|-) (?P<VersionId>[^ ]*)(?: (?P<HostId>[^ ]*) (?P<SigV>[^ ]*) (?P<CipherSuite>[^ ]*) (?P<AuthType>[^ ]*) (?P<EndPoint>[^ ]*) (?P<TLSVersion>[^ ]*))?
+log_pattern = (?P<BucketOwner>[^ ]*) (?P<Bucket>[^ ]*) \[(?P<RequestDateTime>.*?)\] (?P<RemoteIP>[^ ]*) (?P<Requester>[^ ]*) (?P<RequestID>[^ ]*) (?P<Operation>[^ ]*) (?P<Key>[^ ]*) (\"(?P<RequestURI_operation>[^ ]*) (?P<RequestURI_key>[^ ]*) (?P<RequestURI_httpProtoversion>- |[^ ]*)\"|\"-\"|-) (?P<HTTPstatus>-|[0-9]*) (?P<ErrorCode>[^ ]*) (?P<BytesSent>[^ ]*) (?P<ObjectSize>[^ ]*) (?P<TotalTime>[^ ]*) (?P<TurnAroundTime>[^ ]*) (\"(?P<Referrer>[^ ]*)\"|-) (\"(?P<UserAgent>.*)\"|-) (?P<VersionId>[^ ]*)(?: (?P<HostId>[^ ]*) (?P<SigV>[^ ]*) (?P<CipherSuite>[^ ]*) (?P<AuthType>[^ ]*) (?P<EndPoint>[^ ]*) (?P<TLSVersion>[^ ]*))?
 # " close asymmetric bracket
 index_name = log-aws-s3accesslog
 file_format = text


### PR DESCRIPTION
*Issue #, if available:* :None

*Description of changes:*

以下のような UA にダブルクォーテーションを含むログを処理する際に、正規表現で正常にログを認識できなかった点を修正しました。

e.g.)
```
BucketOwner email-contents.sansan.com [24/Dec/2020:20:00:00 +0000] xxx.xxxx.xx.xxx - xxxxxIDxxxx REST.GET.OBJECT aaa/fizzbuzz.txt "GET /some-path/fizzbuzz.txt HTTP/1.1" 200 - 49851 49851 23 22 "https://example,com/some/url" "Mozilla/5.0 (iPad; CPU OS 13_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1"" - someIDstring - ECDHE-RSA-AES128-GCM-SHA256 - s3-ap-northeast-1.amazonaws.com TLSv1.2
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
